### PR TITLE
AQ-149 Editar usuario monitor

### DIFF
--- a/backend/app/controllers/owner/user.owner.controller.js
+++ b/backend/app/controllers/owner/user.owner.controller.js
@@ -85,6 +85,30 @@ class userOwnerController {
             return res.status(500).json(response);
         }
     }
+
+    async updateMonitor(req, res) {
+        try {
+            const { id } = req.params;
+            const monitorData = req.body;
+
+            const result = await this.userOwnerService.updateMonitorUser(id, monitorData);
+
+            const response = ApiResponse.createApiResponse(
+                "Monitor user updated successfully",
+                [result],
+                []
+            );
+
+            return res.json(response);
+        } catch (error) {
+            const response = ApiResponse.createApiResponse(
+                "Error updating monitor user",
+                [],
+                [{ msg: error.message }]
+            );
+            return res.status(500).json(response);
+        }
+    }
 }
 
 module.exports = userOwnerController;

--- a/backend/app/middleware/validateUserMonitorCreation.middleware.js
+++ b/backend/app/middleware/validateUserMonitorCreation.middleware.js
@@ -1,6 +1,6 @@
 const ApiResponse = require('../utils/apiResponse');
 const { ROLES } = require('../enums/roles.enum');
-const { Module, Farm, FarmUser } = require('../../models');
+const { Module, Farm, User } = require('../../models');
 
 class ValidateUserMonitorCreationMiddleware {
     constructor() {}
@@ -8,16 +8,17 @@ class ValidateUserMonitorCreationMiddleware {
     async validate(req, res, next) {
         try {
             const { id_module } = req.body;
-            const user = req.user;
+            const loggedUserId = req.user.id;
 
             if (req.body.id_rol && Number(req.body.id_rol) !== ROLES.MONITOR) {
-                return res.status(400).json(
-                    ApiResponse.createApiResponse('Validation failed',
-                        [],
-                        [{
-                        'error': 'The assigned role must be Monitor (3)'
-                    }])
-                );
+                const response = ApiResponse.createApiResponse(
+                    'Validation Error',
+                    [],
+                    [{
+                        msg: 'The assigned role must be Monitor (3)'
+                    }]
+                )
+                return res.status(400).json(response);
             }
 
             if (!req.body.id_rol) {
@@ -25,64 +26,97 @@ class ValidateUserMonitorCreationMiddleware {
             }
 
             if (!id_module) {
-                return res.status(400).json(
-                    ApiResponse.createApiResponse('Validation failed',
-                        [],
-                        [{
-                        'error': 'A valid module ID is required'
-                    }])
-                );
+                const response = ApiResponse.createApiResponse(
+                    'Validation Error',
+                    [],
+                    [{
+                        msg: 'A valid module ID is required'
+                    }]
+                )
+                return res.status(400).json(response);
             }
 
             const module = await Module.findByPk(id_module, {
                 include: [{
                     model: Farm,
-                    as: 'farm'
+                    as: 'farm',
+                    attributes: ['id', 'name']
                 }]
             });
 
             if (!module) {
-                return res.status(404).json(
-                    ApiResponse.createApiResponse('Validation failed',
-                        [],
-                        [{
-                        'error': 'The specified module does not exist'
-                    }])
-                );
+                const response = ApiResponse.createApiResponse(
+                    'Validation Error',
+                    [],
+                    [{
+                        msg: `The module with ID ${id_module} does not exist in the system`
+                    }]
+                )
+                return res.status(404).json(response);
+            }
+
+            if (!module.farm) {
+                const response = ApiResponse.createApiResponse(
+                    'Validation Error',
+                    [],
+                    [{
+                        msg: `The module with ID ${id_module} does not have an associated farm`
+                    }]
+                )
+                return res.status(404).json(response);
             }
 
             const farmId = module.farm.id;
 
-            const farmUserRelation = await FarmUser.findOne({
-                where: {
-                    id_user: user.id,
-                    id_farm: farmId
-                }
+            const ownerFarms = await Farm.findAll({
+                include: [{
+                    model: User,
+                    as: 'users',
+                    where: { id: loggedUserId },
+                    attributes: [],
+                    through: { attributes: [] }
+                }]
             });
 
-            if (!farmUserRelation) {
-                return res.status(403).json(
-                    ApiResponse.createApiResponse('Validation failed',
-                        [],
-                        [{
-                        'error': 'You do not have permission to create monitors in this module.'
-                    }])
-                );
+            if (!ownerFarms || ownerFarms.length === 0) {
+                const response = ApiResponse.createApiResponse(
+                    'Authorization Error',
+                    [],
+                    [{
+                        msg: 'The owner does not have any farms assigned to manage users'
+                    }]
+                )
+                return res.status(403).json(response);
+            }
+
+            const ownerFarmIds = ownerFarms.map(farm => farm.id);
+
+            if (!ownerFarmIds.includes(farmId)) {
+                const response = ApiResponse.createApiResponse(
+                    'Authorization Error',
+                    [],
+                    [{
+                        msg: 'You do not have permission to create monitors in this module',
+                        details: `The module belongs to the farm ${module.farm.name}, which you do not manage`
+                    }]
+                )
+                return res.status(403).json(response);
             }
 
             next();
         } catch (error) {
-           throw new Error('Error in monitor creation validation: ' + error)
-            return res.status(500).json(
-                ApiResponse.createApiResponse('Server error',
-                    [],
-                    [{
-                    'error': 'Error validating monitor creation: '+ error.message
-                }])
-            );
+            console.error('Error in monitor creation validation:', error);
+            const response = ApiResponse.createApiResponse(
+                'Server Error',
+                [],
+                [{
+                    msg: 'An error occurred while processing monitor user creation validation',
+                    details: error.message
+                }]
+            )
+            return res.status(500).json(response);
         }
     }
 }
 
 module.exports = ValidateUserMonitorCreationMiddleware;
-

--- a/backend/app/middleware/validateUserMonitorUpdate.middleware.js
+++ b/backend/app/middleware/validateUserMonitorUpdate.middleware.js
@@ -1,0 +1,168 @@
+const { User, Farm, Module, sequelize } = require('../../models');
+const ApiResponse = require('../utils/apiResponse');
+
+class ValidateUserMonitorUpdateMiddleware {
+    constructor() {}
+
+    async validate(req, res, next) {
+        try {
+            const userId = req.params.id;
+            const loggedUserId = req.user.id;
+
+            const userToUpdate = await User.findByPk(userId, {
+                include: [
+                    {
+                        model: Module,
+                        as: 'assigned_modules',
+                        attributes: ['id', 'name', 'id_farm'],
+                    }
+                ]
+            });
+
+            if (!userToUpdate) {
+                const response = ApiResponse.createApiResponse(
+                    'Validation Error',
+                    [],
+                    [{ msg: `User with id ${userId} not found in the system` }]
+                )
+                return res.status(404).json(response);
+            }
+
+            const ownerFarms = await Farm.findAll({
+                include: [{
+                    model: User,
+                    as: 'users',
+                    where: { id: loggedUserId },
+                    attributes: [],
+                    through: { attributes: [] }
+                }]
+            });
+
+            if (!ownerFarms || ownerFarms.length === 0) {
+                const response = ApiResponse.createApiResponse(
+                    'Authorization Error',
+                    [],
+                    [{ msg: 'The Owner does not have any assigned farms to manage users' }]
+                )
+                return res.status(403).json(response);
+            }
+
+            const ownerFarmIds = ownerFarms.map(farm => farm.id);
+
+            if (!userToUpdate.assigned_modules || userToUpdate.assigned_modules.length === 0) {
+                if (req.body.id_module) {
+                    const moduleToAssign = await Module.findByPk(req.body.id_module, {
+                        include: [{
+                            model: Farm,
+                            as: 'farm',
+                            attributes: ['id', 'name']
+                        }]
+                    });
+
+                    if (!moduleToAssign) {
+                        const response = ApiResponse.createApiResponse(
+                            'Validation Error',
+                            [],
+                            [{ msg: `Module with id ${req.body.id_module} does not exist in the system` }]
+                        )
+                        return res.status(404).json(response);
+                    }
+
+                    if (!moduleToAssign.farm) {
+                        const response = ApiResponse.createApiResponse(
+                            'Validation Error',
+                            [],
+                            [{ msg: `Module with id ${req.body.id_module} has no associated farm` }]
+                        )
+                        return res.status(404).json(response);
+                    }
+
+                    if (!ownerFarmIds.includes(moduleToAssign.farm.id)) {
+                        const response = ApiResponse.createApiResponse(
+                            'Authorization Error',
+                            [],
+                            [{
+                                msg: 'You cannot assign this module because it belongs to a different farm',
+                                details: `The module belongs to the farm ${moduleToAssign.farm.name}, which is not managed by you`
+                            }]
+                        )
+                        return res.status(403).json(response);
+                    }
+                } else {
+                    return next();
+                }
+            } else {
+                for (const module of userToUpdate.assigned_modules) {
+                    const farmId = module.id_farm;
+
+                    if (!ownerFarmIds.includes(farmId)) {
+                        const response = ApiResponse.createApiResponse(
+                            'Authorization Error',
+                            [],
+                            [{
+                                msg: 'You are not authorized to edit this Monitor user',
+                                details: `The monitor is assigned to module ${module.name} which belongs to a farm that you do not manage`
+                            }]
+                        )
+                        return res.status(403).json(response);
+                    }
+                }
+            }
+
+            if (req.body.id_module) {
+                const moduleToAssign = await Module.findByPk(req.body.id_module, {
+                    include: [{
+                        model: Farm,
+                        as: 'farm',
+                        attributes: ['id', 'name']
+                    }]
+                });
+
+                if (!moduleToAssign) {
+                    const response = ApiResponse.createApiResponse(
+                        'Validation Error',
+                        [],
+                        [{ msg: `Module with id ${req.body.id_module} does not exist in the system` }]
+                    )
+                    return res.status(404).json(response);
+                }
+
+                if (!moduleToAssign.farm) {
+                    const response = ApiResponse.createApiResponse(
+                        'Validation Error',
+                        [],
+                        [{ msg: `Module with id ${req.body.id_module} has no associated farm` }]
+                    )
+                    return res.status(404).json(response);
+                }
+
+                if (!ownerFarmIds.includes(moduleToAssign.farm.id)) {
+                    const response = ApiResponse.createApiResponse(
+                        'Authorization Error',
+                        [],
+                        [{
+                            msg: 'You cannot assign this module because it belongs to a different farm',
+                            details: `The module belongs to the farm ${moduleToAssign.farm.name}, which is not managed by you (${ownerFarmIds.join(', ')})`
+                        }]
+                    )
+                    return res.status(403).json(response);
+                }
+            }
+
+            next();
+        } catch (error) {
+            console.error('Monitor update validation error:', error);
+            const response = ApiResponse.createApiResponse(
+                'Server Error',
+                [],
+                [{
+                    msg: 'Error processing monitor user validation',
+                    details: error.message
+                }]
+            )
+            return res.status(500).json(response);
+        }
+    }
+}
+
+module.exports = ValidateUserMonitorUpdateMiddleware;

--- a/backend/app/routes/owner/user.owner.route.js
+++ b/backend/app/routes/owner/user.owner.route.js
@@ -3,12 +3,14 @@ const router = express.Router();
 
 const {validatePagination} =require('../../validators/shared/user.validator');
 const {validateMonitorRegistration} =require('../../validators/owner/monitor.owner.validator');
+const {validateMonitorUpdate} =require('../../validators/owner/monitor.owner.validator');
 const {validate} = require("../../middleware/validate.middleware");
 const UserOwnerController = require('../../controllers/owner/user.owner.controller');
 const ValidateTokenMiddleware = require('../../middleware/validateToken.middleware');
 const BlackListService = require('../../services/shared/blacklist.service');
 const UserOwnerService = require("../../services/owner/user.owner.service");
 const ValidateModuleAccessMiddleware = require("../../middleware/validateModuleAccess.middleware");
+const ValidateUsrMonitorUpdateMiddleware = require("../../middleware/validateUserMonitorUpdate.middleware");
 
 const { ROLES: Role } = require("../../enums/roles.enum");
 const ValidateRoleMiddleware = require("../../middleware/validateRole.middleware");
@@ -20,6 +22,7 @@ const validateRoleMiddleware = new ValidateRoleMiddleware();
 const userOwnerController = new UserOwnerController(userOwnerService);
 const validateAccess = new ValidateModuleAccessMiddleware();
 const validateUserMonitorCreation = new ValidateUserMonitorCreationMiddleware();
+const validateUserUpdate = new ValidateUsrMonitorUpdateMiddleware();
 
 router.get('/',
     validateTokenMiddleware.validate.bind(validateTokenMiddleware),
@@ -35,6 +38,14 @@ router.post('/',
     validate(validateMonitorRegistration),
     (req, res, next) => validateUserMonitorCreation.validate(req, res, next),
     (req, res) => userOwnerController.createMonitor(req, res)
+);
+
+router.put('/:id',
+    validateTokenMiddleware.validate.bind(validateTokenMiddleware),
+    validateRoleMiddleware.validate([Role.OWNER]),
+    validate(validateMonitorUpdate),
+    (req, res, next) => validateUserUpdate.validate(req, res, next),
+    (req, res) => userOwnerController.updateMonitor(req, res)
 );
 
 module.exports = router;

--- a/backend/app/swagger/paths/owner/update.monitor.json
+++ b/backend/app/swagger/paths/owner/update.monitor.json
@@ -1,56 +1,60 @@
 {
-  "/api/v2/owner/users/": {
-    "post": {
+  "/api/v2/owner/users/{id}": {
+    "put": {
       "tags": [
         "Owner/Users"
       ],
-      "summary": "Create a new monitor user",
-      "description": "Creates a new user with monitor role and associates it with a specific module.\n\n## Features\n\n- Creates a new user with MONITOR role\n- Associates the user with the specified module\n- Sends welcome email with credentials to the new monitor\n- Only accessible by OWNER role users\n\n## Access Control\n\n- **Authentication**: Required (Bearer token)\n- **Role**: OWNER\n- **Permissions**:\n  - Owner must be associated with the farm that owns the module\n  - Can only create MONITOR role users\n  - Module must exist and have an associated farm\n  - The module's farm must be one of the farms managed by the owner\n  - An owner can only create monitors for modules in farms they manage",
+      "summary": "Update an existing monitor user",
+      "description": "Updates an existing user with monitor role and can change its associated module.\n\n## Features\n\n- Updates a monitor user's information\n- Can reassign the monitor to a different module\n- Only accessible by OWNER role users\n- Owners can only update monitors assigned to modules in farms they manage\n\n## Access Control\n\n- **Authentication**: Required (Bearer token)\n- **Role**: OWNER\n- **Permissions**:\n  - Owner must be associated with the farm that owns the module\n  - Can only update MONITOR role users\n  - The module must exist and belong to owner's farm\n  - Monitor user must be assigned to modules from farms managed by the owner",
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "The ID of the monitor user to update",
+          "schema": {
+            "type": "integer"
+          },
+          "example": 57
+        }
+      ],
       "requestBody": {
         "required": true,
         "content": {
           "application/json": {
             "schema": {
               "type": "object",
-              "required": [
-                "name",
-                "email",
-                "dni",
-                "address",
-                "contact",
-                "id_module"
-              ],
               "properties": {
                 "name": {
                   "type": "string",
                   "description": "Full name of the monitor user",
-                  "example": "John Doe"
+                  "example": "John Doe Updated"
                 },
                 "email": {
                   "type": "string",
                   "format": "email",
                   "description": "Valid email address for the monitor user",
-                  "example": "john.doe@example.com"
+                  "example": "john.updated@example.com"
                 },
                 "dni": {
                   "type": "string",
                   "description": "Document or identification number of the monitor user",
-                  "example": "12345678"
+                  "example": "87654321"
                 },
                 "address": {
                   "type": "string",
                   "description": "Physical address where the monitor is located",
-                  "example": "123 Monitoring St, City"
+                  "example": "456 Monitoring St, Updated City"
                 },
                 "contact": {
                   "type": "string",
                   "description": "Contact phone number of the monitor user",
-                  "example": "+1234567890"
+                  "example": "+0987654321"
                 },
                 "id_module": {
                   "type": "integer",
                   "description": "Identifier of the module to be monitored",
-                  "example": 8
+                  "example": 9
                 }
               }
             }
@@ -58,8 +62,8 @@
         }
       },
       "responses": {
-        "201": {
-          "description": "Monitor user created successfully",
+        "200": {
+          "description": "Monitor user updated successfully",
           "content": {
             "application/json": {
               "schema": {
@@ -67,7 +71,7 @@
                 "properties": {
                   "message": {
                     "type": "string",
-                    "example": "Monitor user created successfully"
+                    "example": "Monitor user updated successfully"
                   },
                   "data": {
                     "type": "array",
@@ -80,38 +84,33 @@
                         },
                         "name": {
                           "type": "string",
-                          "example": "John Smith"
+                          "example": "John Doe Updated"
                         },
                         "email": {
                           "type": "string",
                           "format": "email",
-                          "example": "john.smith@acuaterra.tech"
+                          "example": "john.updated@example.com"
                         },
                         "dni": {
                           "type": "string",
-                          "example": "14322621378"
+                          "example": "87654321"
                         },
                         "address": {
                           "type": "string",
-                          "example": "123 Monitor Street"
+                          "example": "456 Monitoring St, Updated City"
                         },
                         "contact": {
                           "type": "string",
-                          "example": "12345789"
+                          "example": "+0987654321"
                         },
                         "id_rol": {
                           "type": "integer",
                           "example": 3
                         },
-                        "createdAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "example": "2025-04-04T20:58:42.000Z"
-                        },
                         "updatedAt": {
                           "type": "string",
                           "format": "date-time",
-                          "example": "2025-04-04T20:58:42.000Z"
+                          "example": "2025-04-06T20:58:42.000Z"
                         },
                         "rol": {
                           "type": "object",
@@ -133,19 +132,19 @@
                             "properties": {
                               "id": {
                                 "type": "integer",
-                                "example": 8
+                                "example": 9
                               },
                               "name": {
                                 "type": "string",
-                                "example": "Tank Module A1"
+                                "example": "Tank Module B2"
                               },
                               "location": {
                                 "type": "string",
-                                "example": "Section B, Building 2"
+                                "example": "Section C, Building 3"
                               },
                               "species_fish": {
                                 "type": "string",
-                                "example": "Tilapia"
+                                "example": "Salmon"
                               }
                             }
                           }
@@ -175,7 +174,7 @@
                 "properties": {
                   "message": {
                     "type": "string",
-                    "example": "Invalid input data for monitor user creation"
+                    "example": "Validation Error"
                   },
                   "data": {
                     "type": "array",
@@ -200,8 +199,8 @@
                     },
                     "example": [
                       {
-                        "msg": "Name is required and must be a valid string",
-                        "param": "name",
+                        "msg": "Email must be a valid email address",
+                        "param": "email",
                         "location": "body"
                       }
                     ]
@@ -273,21 +272,72 @@
                       "properties": {
                         "msg": {
                           "type": "string",
-                          "example": "You do not have permission to create monitors in this module"
+                          "example": "You are not authorized to edit this Monitor user"
                         },
                         "details": {
                           "type": "string",
-                          "example": "The module belongs to the farm Farm A, which you do not manage"
+                          "example": "The monitor is assigned to module Tank A which belongs to a farm that you do not manage"
                         }
                       }
                     },
                     "example": [
                       {
-                        "msg": "The owner does not have any farms assigned to manage users"
+                        "msg": "The Owner does not have any assigned farms to manage users"
                       },
                       {
-                        "msg": "You do not have permission to create monitors in this module",
-                        "details": "The module belongs to the farm Farm A, which you do not manage"
+                        "msg": "You are not authorized to edit this Monitor user",
+                        "details": "The monitor is assigned to module Tank A which belongs to a farm that you do not manage"
+                      },
+                      {
+                        "msg": "You cannot assign this module because it belongs to a different farm",
+                        "details": "The module belongs to the farm Farm B, which is not managed by you (1, 3, 4)"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "example": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "404": {
+          "description": "Not Found - User or module not found",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Validation Error"
+                  },
+                  "data": {
+                    "type": "array",
+                    "example": []
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "msg": {
+                          "type": "string",
+                          "example": "User with id 999 not found in the system"
+                        }
+                      }
+                    },
+                    "example": [
+                      {
+                        "msg": "User with id 999 not found in the system"
+                      },
+                      {
+                        "msg": "Module with id 999 does not exist in the system"
+                      },
+                      {
+                        "msg": "Module with id 123 has no associated farm"
                       }
                     ]
                   },
@@ -309,7 +359,7 @@
                 "properties": {
                   "message": {
                     "type": "string",
-                    "example": "An unexpected error occurred while creating the monitor user"
+                    "example": "Server Error"
                   },
                   "data": {
                     "type": "array",
@@ -322,10 +372,20 @@
                       "properties": {
                         "msg": {
                           "type": "string",
-                          "example": "Error creating Monitor User: Error sending email to the new monitor user: Mail server connection error"
+                          "example": "Error processing monitor user validation"
+                        },
+                        "details": {
+                          "type": "string",
+                          "example": "Database connection error"
                         }
                       }
-                    }
+                    },
+                    "example": [
+                      {
+                        "msg": "Error processing monitor user validation",
+                        "details": "Database connection error"
+                      }
+                    ]
                   },
                   "meta": {
                     "type": "object",

--- a/backend/app/validators/owner/monitor.owner.validator.js
+++ b/backend/app/validators/owner/monitor.owner.validator.js
@@ -1,5 +1,6 @@
 const { body } = require('express-validator');
-const { User } = require('../../../models');
+const { User, Module } = require('../../../models');
+const { Op } = require('sequelize');
 
 const validateMonitorRegistration = [
     body('name')
@@ -50,4 +51,75 @@ const validateMonitorRegistration = [
 
 ];
 
-module.exports = { validateMonitorRegistration };
+const validateMonitorUpdate = [
+    body('name')
+        .notEmpty().withMessage('Name is required')
+        .isString().withMessage('Name must be a string')
+        .trim()
+        .isLength({ min: 3, max: 100 }).withMessage('Name must be between 3 and 100 characters'),
+
+    body('email')
+        .notEmpty().withMessage('Email is required')
+        .isEmail().withMessage('Please provide a valid email address')
+        .trim()
+        .normalizeEmail()
+        .custom(async (value, { req }) => {
+            const userId = req.params.id;
+            const user = await User.findOne({
+                where: {
+                    email: value,
+                    id: { [Op.ne]: userId }
+                }
+            });
+            if (user) {
+                throw new Error('Email already exists');
+            }
+            return true;
+        }),
+
+    body('dni')
+        .notEmpty().withMessage('DNI is required')
+        .isInt().withMessage('DNI must be a Int')
+        .trim()
+        .isLength({ min: 5, max: 100 }).withMessage('DNI must be between 5 and 100 characters')
+        .custom(async (value, { req }) => {
+            const userId = req.params.id;
+            const user = await User.findOne({
+                where: {
+                    dni: value,
+                    id: { [Op.ne]: userId }
+                }
+            });
+            if (user) {
+                throw new Error('DNI already exists');
+            }
+            return true;
+        }),
+
+    body('address')
+        .notEmpty().withMessage('Address is required')
+        .isString().withMessage('Address must be a string')
+        .trim()
+        .isLength({ max: 100 }).withMessage('Address must be a maximum of 100 characters')
+        .matches(/\d+/).withMessage('Address must contain at least one number')
+        .matches(/[a-zA-ZáéíóúÁÉÍÓÚüÜñÑ]+/).withMessage('Address must contain at least one word'),
+
+    body('contact')
+        .notEmpty().withMessage('Contact is required')
+        .isInt().withMessage('Contact must be a Int')
+        .trim()
+        .isLength({ min: 5, max: 100 }).withMessage('Contact must be between 5 and 100 characters'),
+
+    body('id_module')
+        .notEmpty().withMessage('Module ID is required')
+        .isInt().withMessage('Module ID must be an integer')
+        .custom(async (id) => {
+            const module = await Module.findByPk(id);
+            if (!module) {
+                throw new Error('The specified module does not exist');
+            }
+            return true;
+        })
+];
+
+module.exports = { validateMonitorRegistration, validateMonitorUpdate };

--- a/test-resources/user.postman_collection.json
+++ b/test-resources/user.postman_collection.json
@@ -266,6 +266,14 @@
 								}
 							},
 							"response": []
+						},
+						{
+							"name": "update user monitor",
+							"request": {
+								"method": "GET",
+								"header": []
+							},
+							"response": []
 						}
 					]
 				},


### PR DESCRIPTION
### Link Jira
[AQ-149](https://aquaterra-sena.atlassian.net/browse/AQ-149?atlOrigin=eyJpIjoiOWE0ZWQ2MmY1ZGJjNGIxN2JjNDhhYWFlYzU0MTI1YWIiLCJwIjoiaiJ9)

## Description
   I created the complete module editing service, with its MVC, middleware and validator, added its Swagger documentation and its Postman collection, corrected the middleware for creating monitor users since it was allowing monitors to be created in modules that did not correspond to their associated farm.
## New Environments

### Screenshots
  
![image](https://github.com/user-attachments/assets/4ce80b5e-1d68-467e-ba8e-9055a00a3357)
![image](https://github.com/user-attachments/assets/e3ca61af-3533-46f6-9155-5842fc1f1dec)

  