### PR TITLE
AQ-156 Fix query exceptions for get by id of modules so that the deleteSoft …

### DIFF
--- a/backend/app/services/owner/module.owner.services.js
+++ b/backend/app/services/owner/module.owner.services.js
@@ -318,6 +318,7 @@ class ModuleOwnerService {
                         model: Farm,
                         as: 'farm',
                         attributes: ['id', 'name'],
+                        required: true,
                         where: {
                             isActive: true
                         }
@@ -326,6 +327,7 @@ class ModuleOwnerService {
                         model: User,
                         as: 'creator',
                         attributes: ['id', 'name', 'email'],
+                        required: false,
                         where: {
                             isActive: true
                         }
@@ -335,6 +337,7 @@ class ModuleOwnerService {
                         as: 'users',
                         attributes: ['id', 'name', 'email', 'dni'],
                         through: { attributes: [] },
+                        required: false,
                         where: {
                             isActive: true
                         }
@@ -342,17 +345,14 @@ class ModuleOwnerService {
                     {
                         model: Sensor,
                         as: 'sensors',
-                        attributes: ['id', 'name'],
-                        where: {
-                            isActive: true
-                        },
+                        attributes: ['id', 'name', 'type', 'isActive'],
+                        required: false,
                         include: [
                             {
                                 model: Threshold,
                                 as: 'thresholds',
-                                where: {
-                                    isActive: true
-                                }
+                                attributes: ['id', 'type', 'value', 'isActive'],
+                                required: false
                             }
                         ]
                     }


### PR DESCRIPTION
### Link Jira
[AQ-156](https://aquaterra-sena.atlassian.net/browse/AQ-156?atlOrigin=eyJpIjoiOWE0ZWQ2MmY1ZGJjNGIxN2JjNDhhYWFlYzU0MTI1YWIiLCJwIjoiaiJ9)

## Description
Fix query exceptions for get by id of modules so that the deleteSoft is only reflected from the parent nodes following the hierarchy order of a cascade soft delete, preventing child nodes from canceling information from parent nodes, making queries with conditionals not required only where the queries of child nodes are found
## New Environments

### Screenshots
 
![image](https://github.com/user-attachments/assets/cbe75605-f619-417f-ab3d-23cc680d1a21)