### PR TITLE
AQ- 166 List monitors with is active=true field

### DIFF
--- a/backend/app/controllers/owner/user.owner.controller.js
+++ b/backend/app/controllers/owner/user.owner.controller.js
@@ -1,5 +1,5 @@
 const ApiResponse = require('../../utils/apiResponse');
-
+const { ROLES } = require('../../enums/roles.enum');
 class userOwnerController {
     constructor(userOwnerService) {
         this.userOwnerService = userOwnerService;
@@ -153,6 +153,38 @@ class userOwnerController {
         } catch (error) {
             const response = ApiResponse.createApiResponse(
                 "Error reactivating the monitor",
+                [],
+                [{ msg: error.message }]
+            );
+            return res.status(500).json(response);
+        }
+    }
+
+    async getActiveMonitors(req, res) {
+        try {
+            const ownerFarmIds = req.user.id_rol === ROLES.OWNER ? req.ownerFarmIds : null;
+            const result = await this.userOwnerService.getActiveMonitors(ownerFarmIds);
+            
+            if (result.length === 0) {
+                const response = ApiResponse.createApiResponse(
+                    "No active monitors available.",
+                    [],
+                    []
+                );
+                return res.json(response);
+            }
+
+            const response = ApiResponse.createApiResponse(
+                "Active monitors successfully recovered",
+                [result],
+                []
+            );
+
+            return res.json(response);
+        } catch (error) {
+            console.error("Error getting active monitors:", error);
+            const response = ApiResponse.createApiResponse(
+                "Error getting active monitors",
                 [],
                 [{ msg: error.message }]
             );

--- a/backend/app/middleware/validateOwnerMonitorAccess.middleware.js
+++ b/backend/app/middleware/validateOwnerMonitorAccess.middleware.js
@@ -1,0 +1,56 @@
+const { Farm, User, Module } = require('../../models');
+const ApiResponse = require("../utils/apiResponse");
+const { ROLES } = require('../enums/roles.enum');
+const { Op } = require('sequelize');
+
+class ValidateOwnerMonitorAccessMiddleware {
+    async validate(req, res, next) {
+        try {
+            if (req.user.id_rol === ROLES.OWNER) {
+                const ownerId = req.user.id;
+
+                const ownerFarms = await Farm.findAll({
+                    where: { 
+                        isActive: true 
+                    },
+                    include: [{
+                        model: User,
+                        as: 'users',
+                        where: { 
+                            id: ownerId,
+                            isActive: true 
+                        },
+                        through: { attributes: [] }
+                    }]
+                });
+
+                if (!ownerFarms || ownerFarms.length === 0) {
+                    const response = ApiResponse.createApiResponse(
+                            'He has no access to any farm',
+                            [],
+                            [{
+                                msg: 'Has no farms assigned or active'
+                            }])
+                    return res.status(403).json(response);
+                }
+
+                req.ownerFarmIds = ownerFarms.map(farm => farm.id);
+            }
+            
+            next();
+        } catch (error) {
+            console.error('Error in access validation to monitors:', error);
+            const response = ApiResponse.createApiResponse(
+                'Server error',
+                [],
+                [{
+                    msg: 'Error validating access permissions'
+                }]
+            )
+            return res.status(500).json(response);
+        }
+    }
+}
+
+module.exports = ValidateOwnerMonitorAccessMiddleware;
+

--- a/backend/app/routes/owner/user.owner.route.js
+++ b/backend/app/routes/owner/user.owner.route.js
@@ -17,6 +17,8 @@ const ValidateRoleMiddleware = require("../../middleware/validateRole.middleware
 const ValidateUserMonitorCreationMiddleware = require("../../middleware/validateUserMonitorCreation.middleware");
 const ValidateMonitorDisableMiddleware = require("../../middleware/validateMonitorDisable.middleware");
 const ValidateMonitorReactivateMiddleware = require("../../middleware/validateMonitorReactivate.middleware");
+const ValidateOwnerMonitorAccessMiddleware = require("../../middleware/validateOwnerMonitorAccess.middleware");
+
 const validateTokenMiddleware = new ValidateTokenMiddleware(new BlackListService());
 const userOwnerService = new UserOwnerService();
 const validateRoleMiddleware = new ValidateRoleMiddleware();
@@ -26,6 +28,8 @@ const validateUserMonitorCreation = new ValidateUserMonitorCreationMiddleware();
 const validateUserUpdate = new ValidateUsrMonitorUpdateMiddleware();
 const validateMonitorDisable = new ValidateMonitorDisableMiddleware();
 const validateMonitorReactivate = new ValidateMonitorReactivateMiddleware();
+const validateOwnerMonitorAccess = new ValidateOwnerMonitorAccessMiddleware();
+
 router.get('/',
     validateTokenMiddleware.validate.bind(validateTokenMiddleware),
     validateRoleMiddleware.validate([Role.OWNER]),
@@ -62,6 +66,14 @@ router.patch('/:id',
     validateRoleMiddleware.validate([Role.OWNER]),
     (req, res, next) => validateMonitorReactivate.validate(req, res, next),
     (req, res) => userOwnerController.reactivateMonitor(req, res)
+);
+
+
+router.get('/monitors',
+    validateTokenMiddleware.validate.bind(validateTokenMiddleware),
+    validateRoleMiddleware.validate([Role.OWNER]),
+    (req, res, next) => validateOwnerMonitorAccess.validate(req, res, next),
+    (req, res) => userOwnerController.getActiveMonitors(req, res)
 );
 
 module.exports = router;

--- a/backend/app/swagger/paths/owner/get-active-monitors.json
+++ b/backend/app/swagger/paths/owner/get-active-monitors.json
@@ -1,0 +1,212 @@
+{
+  "/api/v2/owner/users/monitors": {
+    "get": {
+      "summary": "Get list of active monitors",
+      "tags": ["Owner/Users"],
+      "description": "Returns a list of active monitors associated with the owner's farms and modules. The endpoint performs the following validations and filters:\n1. Verifies user has OWNER role\n2. Checks for active farms associated with the owner\n3. Retrieves monitors linked to owner's farms and modules\n4. Filters out inactive monitors\n5. Returns a simplified list format for checkbox usage in forms.\n\nNote: If the owner has no active farms or modules, an empty list will be returned.",
+      "security": [
+        {
+          "bearerAuth": []
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Successful operation",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "fullName": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "msg": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "success": {
+                  "summary": "Successful response with monitors",
+                  "value": {
+                    "message": "Active monitors successfully recovered",
+                    "data": [
+                      {
+                        "id": 1,
+                        "fullName": "John Doe"
+                      },
+                      {
+                        "id": 2,
+                        "fullName": "Jane Smith"
+                      }
+                    ],
+                    "errors": []
+                  }
+                },
+                "empty": {
+                  "summary": "Successful response with no monitors",
+                  "value": {
+                    "message": "No active monitors available.",
+                    "data": [],
+                    "errors": []
+                  }
+                }
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized - Invalid or missing token",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "array"
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "msg": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "unauthorized": {
+                  "summary": "Invalid or missing token",
+                  "value": {
+                    "message": "Unauthorized",
+                    "data": [],
+                    "errors": [
+                      {
+                        "msg": "Invalid token or token not provided"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden - User does not have access to any farm",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "array"
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "msg": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "noAccess": {
+                  "summary": "No access to farms",
+                  "value": {
+                    "message": "He has no access to any farm",
+                    "data": [],
+                    "errors": [
+                      {
+                        "msg": "Has no farms assigned or active"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string"
+                  },
+                  "data": {
+                    "type": "array"
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "msg": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "examples": {
+                "serverError": {
+                  "summary": "Internal server error",
+                  "value": {
+                    "message": "Error getting active monitors",
+                    "data": [],
+                    "errors": [
+                      {
+                        "msg": "Error validating access permissions"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test-resources/user.postman_collection.json
+++ b/test-resources/user.postman_collection.json
@@ -174,7 +174,7 @@
 					"name": "owner",
 					"item": [
 						{
-							"name": "lsit monitores Mobile",
+							"name": "lsit monitores Mobile actives and inactives",
 							"request": {
 								"method": "GET",
 								"header": [
@@ -343,6 +343,35 @@
 										"owner",
 										"users",
 										"59"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "lsit monitores Mobile actives",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZG5pIjoiMDIzMTI2NjM5MiIsImlhdCI6MTc0NDkyODgzNSwiZXhwIjoxNzQ0OTQ2ODM1fQ.xayLwaeaK7jB_yYO1UOUvRTxhtnljkxd8vlXx3QjU-Y",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "http://localhost:3000/api/v2/owner/users/monitors",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "3000",
+									"path": [
+										"api",
+										"v2",
+										"owner",
+										"users",
+										"monitors"
 									]
 								}
 							},


### PR DESCRIPTION
### Link Jira
[AQ-166](https://aquaterra-sena.atlassian.net/browse/AQ-66?atlOrigin=eyJpIjoiOWE0ZWQ2MmY1ZGJjNGIxN2JjNDhhYWFlYzU0MTI1YWIiLCJwIjoiaiJ9)

## Description
   Add a complete service with your MVC, middleware, Swagger documentation and Postman collection update, to display the monitors that belong to a farm assigned to a logged-in owner to be consumed by a checkbox that will only show the active monitors, through two fields: full name and ID for easy configuration through the checkbox.
## New Environments
   
### Screenshots
  
![image](https://github.com/user-attachments/assets/c99be486-0979-4121-b92d-25e4d925c92d)

  