### PR TITLE
AQ-170 Service arrangement for displaying monitors

### DIFF
--- a/backend/app/controllers/owner/user.owner.controller.js
+++ b/backend/app/controllers/owner/user.owner.controller.js
@@ -13,9 +13,7 @@ class userOwnerController {
             const sortOrder = req.query.sortOrder || 'DESC';
             const ownerId = req.user.id;
             
-            const ownerModuleIds = req.ownerModuleIds || [];
-
-            const result = await this.userOwnerService.getMonitorUsers(ownerId, page, limit, sortField, sortOrder, ownerModuleIds);
+            const result = await this.userOwnerService.getMonitorUsers(ownerId, page, limit, sortField, sortOrder);
 
             if (result.rows.length === 0) {
                 const paginationMeta = {
@@ -29,7 +27,7 @@ class userOwnerController {
                     }
                 };
                 const response = ApiResponse.createApiResponse(
-                    "There are no monitors available at partner farms.",
+                    "No monitors found associated with your farms.",
                     [],
                     [],
                     paginationMeta
@@ -69,7 +67,13 @@ class userOwnerController {
 
     async createMonitor(req, res) {
         try {
-            const monitorData = req.body;
+            const ownerId = req.user.id;
+            const monitorData = {
+                ...req.body,
+                createdBy: ownerId,
+                updatedBy: ownerId
+            };
+            
             const result = await this.userOwnerService.createMonitorUser(monitorData);
 
             const response = ApiResponse.createApiResponse(

--- a/backend/app/swagger/paths/owner/create.monitor.json
+++ b/backend/app/swagger/paths/owner/create.monitor.json
@@ -5,7 +5,7 @@
         "Owner/Users"
       ],
       "summary": "Create a new monitor user",
-      "description": "Creates a new user with monitor role.\n\n## Features\n\n- Creates a new user with MONITOR role\n- Sends welcome email with credentials to the new monitor\n- Only accessible by OWNER role users\n\n## Access Control\n\n- **Authentication**: Required (Bearer token)\n- **Role**: OWNER\n- **Permissions**:\n  - Can only create MONITOR role users\n\n## Automatic Processing\n\n- The `id_rol` is automatically set to MONITOR (3) if not provided\n- Any `farm_id` in the request body is automatically removed for security reasons\n\n## Validation Rules\n\n- **name**: Required, must be a string between 3 and 100 characters\n- **email**: Required, must be a valid email format, must be unique in the system\n- **dni**: Required, must be an integer between 5 and 100 characters, must be unique in the system\n- **address**: Required, must be a string (max 100 characters) containing at least one number and one word\n- **contact**: Required, must be an integer between 5 and 100 characters",
+      "description": "Creates a new user with monitor role and automatically associates them with the owner's farms.\n\n## Features\n\n- Creates a new user with MONITOR role\n- Automatically associates the monitor with all active farms of the authenticated owner\n- Sends welcome email with credentials to the new monitor\n- Only accessible by OWNER role users\n\n## Access Control\n\n- **Authentication**: Required (Bearer token)\n- **Role**: OWNER\n- **Permissions**:\n  - Can only create MONITOR role users\n\n## Automatic Processing\n\n- The `id_rol` is automatically set to MONITOR (3) if not provided\n- The monitor is automatically associated with all active farms of the owner\n- Any `farm_id` in the request body is automatically removed for security reasons\n\n## Validation Rules\n\n- **name**: Required, must be a string between 3 and 100 characters\n- **email**: Required, must be a valid email format, must be unique in the system\n- **dni**: Required, must be an integer between 5 and 100 characters, must be unique in the system\n- **address**: Required, must be a string (max 100 characters) containing at least one number and one word\n- **contact**: Required, must be an integer between 5 and 100 characters",
       "requestBody": {
         "required": true,
         "content": {
@@ -124,6 +124,35 @@
                               "example": "MONITOR"
                             }
                           }
+                        },
+                        "farms": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "id": {
+                                "type": "integer",
+                                "example": 14
+                              },
+                              "name": {
+                                "type": "string",
+                                "example": "Farm Alpha"
+                              },
+                              "address": {
+                                "type": "string",
+                                "example": "123 Farm Road"
+                              },
+                              "latitude": {
+                                "type": "string",
+                                "example": "4.6097102"
+                              },
+                              "longitude": {
+                                "type": "string",
+                                "example": "-74.0817500"
+                              }
+                            }
+                          },
+                          "description": "List of farms associated with the monitor user"
                         }
                       }
                     }
@@ -303,6 +332,9 @@
                     "example": [
                       {
                         "msg": "Error creating Monitor User: Error sending email to the new monitor user: Mail server connection error"
+                      },
+                      {
+                        "msg": "Error creating Monitor User: No active farms found for this owner"
                       }
                     ]
                   },

--- a/backend/app/swagger/paths/owner/get_list_monitor_asociate.json
+++ b/backend/app/swagger/paths/owner/get_list_monitor_asociate.json
@@ -1,9 +1,9 @@
 {
   "/api/v2/owner/users": {
     "get": {
-      "summary": "Get monitor users associated with owner's modules",
+      "summary": "Get monitor users associated with owner's farms",
       "tags": ["Owner/Users"],
-      "description": "Retrieves a paginated list of MONITOR users (id_rol = 3) that are associated with modules from the authenticated owner's farms, including both active and inactive monitors.\n\n## Features\n\n- Lists only users with MONITOR role (id_rol = 3)\n- Shows both active and inactive monitor users\n- Shows only users associated with modules that belong to the authenticated user's farms\n- Includes pagination and sorting capabilities\n\n",
+      "description": "Retrieves a paginated list of MONITOR users (id_rol = 3) that are associated with the authenticated owner's farms, including both active and inactive monitors.\n\n## Features\n\n- Lists only users with MONITOR role (id_rol = 3)\n- Shows both active and inactive monitor users\n- Shows only users associated with farms belonging to the authenticated owner\n- Includes pagination and sorting capabilities\n\n",
       "responses": {
         "200": {
           "description": "Monitor users retrieved successfully",
@@ -56,7 +56,7 @@
                           "example": true,
                           "description": "Indicates whether the monitor user is active (true) or inactive (false)"
                         },
-                        "assigned_modules": {
+                        "farms": {
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -67,19 +67,23 @@
                               },
                               "name": {
                                 "type": "string",
-                                "example": "modulo D"
+                                "example": "Farm Alpha"
                               },
-                              "location": {
+                              "address": {
                                 "type": "string",
-                                "example": "Ubicación del módulo 123"
+                                "example": "123 Farm Road"
                               },
-                              "species_fish": {
+                              "latitude": {
                                 "type": "string",
-                                "example": "Especie de pez"
+                                "example": "4.6097102"
+                              },
+                              "longitude": {
+                                "type": "string",
+                                "example": "-74.0817500"
                               }
                             }
                           },
-                          "description": "List of modules associated with the monitor user"
+                          "description": "List of farms associated with the monitor user"
                         },
                         "rol": {
                           "type": "object",
@@ -152,7 +156,7 @@
           }
         },
         "403": {
-          "description": "Forbidden - No monitor users found or no access to modules",
+          "description": "Forbidden - No monitor users found or no access to farms",
           "content": {
             "application/json": {
               "schema": {
@@ -170,10 +174,10 @@
                     "type": "array",
                     "example": [
                       {
-                        "msg": "You do not have access to any modules through your farms."
+                        "msg": "You do not have access to any farms."
                       },
                       {
-                        "msg": "There are no monitors (active or inactive) available at partner farms."
+                        "msg": "No monitors found associated with your farms."
                       }
                     ]
                   }
@@ -201,7 +205,7 @@
                     "type": "array",
                     "example": [
                       {
-                        "msg": "Error getting monitor users: Farm is associated to Module using an alias. You must use the 'as' keyword to specify the alias within your include statement."
+                        "msg": "Error getting monitor users: Database connection error"
                       }
                     ]
                   }

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -11,7 +11,8 @@ module.exports = (sequelize) => {
       User.belongsToMany(models.Farm, {
         through: 'farm_user',
         foreignKey: 'id_user',
-        otherKey: 'id_farm'
+        otherKey: 'id_farm',
+        as: 'farms'
       });
       
       User.hasMany(models.Module, {


### PR DESCRIPTION
### Link Jira
[AQ-170](https://aquaterra-sena.atlassian.net/browse/AQ-170?atlOrigin=eyJpIjoiOWE0ZWQ2MmY1ZGJjNGIxN2JjNDhhYWFlYzU0MTI1YWIiLCJwIjoiaiJ9)

## Description
   Service arrangement to create and display monitors, since when creating them, the monitor must be associated with the farm assigned to the logged-in owner who is creating the monitor, and only the monitors associated with that farm should appear in the list.
## New Environments
![image](https://github.com/user-attachments/assets/fd0fdc4f-69a7-4920-add3-e399730f47d5)
![image](https://github.com/user-attachments/assets/34eaad49-1879-4fe1-b02f-8dfd164d9197)
![image](https://github.com/user-attachments/assets/e21a56ca-e869-4186-b6e0-314fdb38e607)
![image](https://github.com/user-attachments/assets/44486988-bb79-4081-bbe0-9fc0616ed79c)
  
  
