### PR TITLE
Feature/aq 167 implement middleware reuse routes

### DIFF
--- a/backend/app/middleware/validateUserAccess.middleware.js
+++ b/backend/app/middleware/validateUserAccess.middleware.js
@@ -1,0 +1,282 @@
+// middlewares/validateUserAccess.middleware.js
+const ApiResponse = require("../utils/apiResponse");
+const { User, Farm, Module, ModuleUser, FarmUser } = require("../../models");
+const { ROLES } = require("../enums/roles.enum");
+
+class ValidateUserAccessMiddleware {
+  constructor() {
+    // Bind methods to ensure 'this' context is preserved
+    this.extendRoleValidation = this.extendRoleValidation.bind(this);
+    this.handleRoleBasedAccess = this.handleRoleBasedAccess.bind(this);
+    this.filterFarmsByMonitor = this.filterFarmsByMonitor.bind(this);
+    this.filterModulesByMonitor = this.filterModulesByMonitor.bind(this);
+    this.restrictCrudForMonitor = this.restrictCrudForMonitor.bind(this);
+    this.checkMonitorAccess = this.checkMonitorAccess.bind(this);
+  }
+
+  /**
+   * Extends the ValidateRoleMiddleware to accept both OWNER and MONITOR roles for GET requests
+   * Works as a middleware factory - returns a middleware function
+   * @returns {Function} Express middleware function
+   */
+  extendRoleValidation() {
+    return async (req, res, next) => {
+      try {
+        // GET requests can be accessed by both OWNER and MONITOR
+        if (req.method === 'GET') {
+          // Original role middleware already validated and set req.user
+          // We just need to set additional flags for role-based behavior
+          if (req.user && req.user.id_rol === ROLES.MONITOR) {
+            req.isMonitor = true;
+            req.userId = req.user.id;
+            // Continue to next middleware which will handle filtering
+            return next();
+          } else if (req.user && req.user.id_rol === ROLES.OWNER) {
+            req.isMonitor = false;
+            req.userId = req.user.id;
+            // Owners get full access without additional filtering
+            return next();
+          }
+        } else if (req.method !== 'GET' && req.user && req.user.id_rol === ROLES.MONITOR) {
+          // For non-GET requests, if user is a MONITOR, block access
+          return res.status(403).json(
+            ApiResponse.createApiResponse('Access denied', [], [{
+              'error': 'Monitors can only perform read operations'
+            }])
+          );
+        }
+
+        // For all other cases, proceed normally
+        next();
+      } catch (error) {
+        console.error('Error in extendRoleValidation middleware:', error);
+        return res.status(500).json(
+          ApiResponse.createApiResponse('Server error', [], [{
+            'error': error.message
+          }])
+        );
+      }
+    };
+  }
+
+  /**
+   * Main middleware that handles role-based access control
+   * Must be applied after validateToken and validateRole middlewares
+   * @returns {Function} Express middleware function
+   */
+  handleRoleBasedAccess() {
+    return async (req, res, next) => {
+      try {
+        // Skip if not a monitor or if user data is missing
+        if (!req.isMonitor || !req.user) {
+          return next();
+        }
+
+        // Store original response.json to intercept the response
+        const originalJson = res.json;
+        const monitorId = req.user.id;
+
+        // Check the route path to determine what kind of resource is being accessed
+        const path = req.path;
+
+        // Determine what filter should be applied based on the path
+        let filterFunction = null;
+        if (path.startsWith('/farms') || path === '/') {
+          filterFunction = (data) => this.filterFarmsByMonitor(data, monitorId);
+        } else if (path.includes('/modules') || path.includes('/module/')) {
+          filterFunction = (data) => this.filterModulesByMonitor(data, monitorId);
+        } else if (path.includes('/monitors')) {
+          // For monitor routes, leave data as is - monitors can view other monitors
+          filterFunction = (data) => data;
+        }
+
+        // Override response.json to intercept and filter the data
+        if (filterFunction) {
+          res.json = function(data) {
+            // Reset the json method to avoid infinite recursion
+            res.json = originalJson;
+
+            // If data has the API response structure, filter its content
+            if (data && data.data) {
+              data.data = filterFunction(data.data);
+            }
+
+            // Call the original json method with the filtered data
+            return originalJson.call(this, data);
+          };
+        }
+
+        next();
+      } catch (error) {
+        console.error('Error in handleRoleBasedAccess middleware:', error);
+        return res.status(500).json(
+          ApiResponse.createApiResponse('Server error', [], [{
+            'error': error.message
+          }])
+        );
+      }
+    };
+  }
+
+  /**
+   * Filter farms to only include those associated with the monitor
+   * @param {Array} farms - Array of farms from the controller response
+   * @param {Number} id_user - ID of the monitor
+   * @returns {Array} Filtered array of farms
+   */
+  async filterFarmsByMonitor(farms, id_user) {
+    try {
+      if (!Array.isArray(farms)) {
+        return farms; // Return as is if not an array
+      }
+
+      // Get all farm IDs associated with this monitor
+      const monitorFarms = await FarmUser.findAll({
+        where: { id_user: id_user },
+        attributes: ['id_farm']
+      });
+
+      const allowedFarmIds = monitorFarms.map(mf => mf.id_farm);
+
+      // Filter the farms array to only include farms associated with the monitor
+      return farms.filter(farm => allowedFarmIds.includes(farm.id));
+    } catch (error) {
+      console.error('Error filtering farms by monitor:', error);
+      return []; // Return empty array in case of error
+    }
+  }
+
+  /**
+   * Filter modules to only include those associated with the monitor
+   * @param {Array} modules - Array of modules from the controller response
+   * @param {Number} monitorId - ID of the monitor
+   * @returns {Array} Filtered array of modules
+   */
+  async filterModulesByMonitor(modules, monitorId) {
+    try {
+      if (!Array.isArray(modules)) {
+        return modules; // Return as is if not an array
+      }
+
+      // Get all module IDs associated with this monitor
+      const monitorModules = await FarmUser.findAll({
+        where: { monitor_id: monitorId },
+        attributes: ['module_id']
+      });
+
+      const allowedModuleIds = monitorModules.map(mm => mm.module_id);
+
+      // Filter the modules array to only include modules associated with the monitor
+      return modules.filter(module => allowedModuleIds.includes(module.id));
+    } catch (error) {
+      console.error('Error filtering modules by monitor:', error);
+      return []; // Return empty array in case of error
+    }
+  }
+
+  /**
+   * Restricts CRUD operations for monitors, allowing only GET requests
+   * @returns {Function} Express middleware function
+   */
+  restrictCrudForMonitor() {
+    return (req, res, next) => {
+      try {
+        // Skip validation if not a monitor or if user data is missing
+        if (!req.isMonitor || !req.user) {
+          return next();
+        }
+
+        // Allow only GET requests for monitors
+        if (req.method !== 'GET') {
+          return res.status(403).json(
+            ApiResponse.createApiResponse('Access denied', [], [{
+              'error': 'Monitors can only perform read operations'
+            }])
+          );
+        }
+
+        next();
+      } catch (error) {
+        console.error('Error in restrictCrudForMonitor middleware:', error);
+        return res.status(500).json(
+          ApiResponse.createApiResponse('Server error', [], [{
+            'error': error.message
+          }])
+        );
+      }
+    };
+  }
+
+  /**
+   * Checks if a monitor has access to a specific resource (farm, module, etc.)
+   * @param {String} resourceType - Type of resource to check ('farm', 'module', etc.)
+   * @returns {Function} Express middleware function
+   */
+  checkMonitorAccess(resourceType) {
+    return async (req, res, next) => {
+      try {
+        // Skip validation if not a monitor or if user data is missing
+        if (!req.isMonitor || !req.user) {
+          return next();
+        }
+
+        const monitorId = req.user.id;
+        let hasAccess = false;
+
+        switch(resourceType) {
+          case 'farm':
+            const id_farm = req.params.id || req.body.id_farm;
+            if (!id_farm) {
+              return next(); // No farm ID to check, proceed
+            }
+
+            hasAccess = await FarmUser.findOne({
+              where: {
+                monitor_id: monitorId,
+                id_farm: id_farm
+              }
+            });
+            break;
+
+          case 'module':
+            const moduleId = req.params.id || req.params.moduleId || req.body.module_id;
+            if (!moduleId) {
+              return next(); // No module ID to check, proceed
+            }
+
+            hasAccess = await ModuleUser.findOne({
+              where: {
+                monitor_id: monitorId,
+                module_id: moduleId
+              }
+            });
+            break;
+
+          default:
+            // Unknown resource type, allow access
+            return next();
+        }
+
+        if (!hasAccess) {
+          return res.status(403).json(
+            ApiResponse.createApiResponse('Access denied', [], [{
+              'error': `Monitor does not have access to this ${resourceType}`
+            }])
+          );
+        }
+
+        next();
+      } catch (error) {
+        console.error(`Error checking monitor access to ${resourceType}:`, error);
+        return res.status(500).json(
+          ApiResponse.createApiResponse('Server error', [], [{
+            'error': error.message
+          }])
+        );
+      }
+    };
+  }
+}
+
+module.exports = ValidateUserAccessMiddleware;
+

--- a/backend/app/middleware/validateUserAccess.middleware.js
+++ b/backend/app/middleware/validateUserAccess.middleware.js
@@ -1,11 +1,9 @@
-// middlewares/validateUserAccess.middleware.js
 const ApiResponse = require("../utils/apiResponse");
-const { User, Farm, Module, ModuleUser, FarmUser } = require("../../models");
+const {  Farm, ModuleUser, FarmUser } = require("../../models");
 const { ROLES } = require("../enums/roles.enum");
 
 class ValidateUserAccessMiddleware {
   constructor() {
-    // Bind methods to ensure 'this' context is preserved
     this.extendRoleValidation = this.extendRoleValidation.bind(this);
     this.handleRoleBasedAccess = this.handleRoleBasedAccess.bind(this);
     this.filterFarmsByMonitor = this.filterFarmsByMonitor.bind(this);
@@ -14,39 +12,26 @@ class ValidateUserAccessMiddleware {
     this.checkMonitorAccess = this.checkMonitorAccess.bind(this);
   }
 
-  /**
-   * Extends the ValidateRoleMiddleware to accept both OWNER and MONITOR roles for GET requests
-   * Works as a middleware factory - returns a middleware function
-   * @returns {Function} Express middleware function
-   */
   extendRoleValidation() {
     return async (req, res, next) => {
       try {
-        // GET requests can be accessed by both OWNER and MONITOR
         if (req.method === 'GET') {
-          // Original role middleware already validated and set req.user
-          // We just need to set additional flags for role-based behavior
           if (req.user && req.user.id_rol === ROLES.MONITOR) {
             req.isMonitor = true;
             req.userId = req.user.id;
-            // Continue to next middleware which will handle filtering
             return next();
           } else if (req.user && req.user.id_rol === ROLES.OWNER) {
             req.isMonitor = false;
             req.userId = req.user.id;
-            // Owners get full access without additional filtering
             return next();
           }
         } else if (req.method !== 'GET' && req.user && req.user.id_rol === ROLES.MONITOR) {
-          // For non-GET requests, if user is a MONITOR, block access
           return res.status(403).json(
             ApiResponse.createApiResponse('Access denied', [], [{
               'error': 'Monitors can only perform read operations'
             }])
           );
         }
-
-        // For all other cases, proceed normally
         next();
       } catch (error) {
         console.error('Error in extendRoleValidation middleware:', error);
@@ -59,49 +44,78 @@ class ValidateUserAccessMiddleware {
     };
   }
 
-  /**
-   * Main middleware that handles role-based access control
-   * Must be applied after validateToken and validateRole middlewares
-   * @returns {Function} Express middleware function
-   */
   handleRoleBasedAccess() {
     return async (req, res, next) => {
       try {
-        // Skip if not a monitor or if user data is missing
         if (!req.isMonitor || !req.user) {
           return next();
         }
-
-        // Store original response.json to intercept the response
         const originalJson = res.json;
         const monitorId = req.user.id;
 
-        // Check the route path to determine what kind of resource is being accessed
         const path = req.path;
 
-        // Determine what filter should be applied based on the path
         let filterFunction = null;
         if (path.startsWith('/farms') || path === '/') {
           filterFunction = (data) => this.filterFarmsByMonitor(data, monitorId);
         } else if (path.includes('/modules') || path.includes('/module/')) {
           filterFunction = (data) => this.filterModulesByMonitor(data, monitorId);
         } else if (path.includes('/monitors')) {
-          // For monitor routes, leave data as is - monitors can view other monitors
           filterFunction = (data) => data;
         }
 
-        // Override response.json to intercept and filter the data
         if (filterFunction) {
-          res.json = function(data) {
-            // Reset the json method to avoid infinite recursion
+          res.json = async function(data) {
             res.json = originalJson;
 
-            // If data has the API response structure, filter its content
-            if (data && data.data) {
-              data.data = filterFunction(data.data);
-            }
+            try {
+              if (data && typeof data === 'object') {
+                if (
+                  data.hasOwnProperty('data') &&
+                  typeof data.data === 'object' &&
+                  !Array.isArray(data.data) &&
+                  Object.keys(data.data).length === 0 &&
+                  data.meta?.pagination?.total > 0
+                ) {
+                  if (req.path.startsWith('/farms') || req.path === '/') {
 
-            // Call the original json method with the filtered data
+                    const monitorFarms = await FarmUser.findAll({
+                      where: { id_user: monitorId },
+                      attributes: ['id_farm']
+                    });
+
+                    if (monitorFarms && monitorFarms.length > 0) {
+                      const allowedFarmIds = monitorFarms.map(mf => mf.id_farm);
+
+                      const farms = await Farm.findAll({
+                        where: {
+                          id: allowedFarmIds,
+                          isActive: true
+                        }
+                      });
+
+                      data.data = farms.map(farm => farm.toJSON ? farm.toJSON() : farm);
+                    }
+                  } else {
+                    const filteredData = await filterFunction(data.data);
+                    if (Array.isArray(filteredData) && filteredData.length > 0) {
+                      data.data = filteredData;
+                    }
+                  }
+                } else if (data.hasOwnProperty('data')) {
+                  const filteredData = await filterFunction(data.data);
+
+                  if (Array.isArray(filteredData)) {
+                    data.data = filteredData;
+                  } else if (filteredData && typeof filteredData === 'object') {
+                    data.data = filteredData;
+                  }
+                }
+              }
+            } catch (error) {
+              console.error("Error in response intercept:", error);
+              console.error(error.stack);
+            }
             return originalJson.call(this, data);
           };
         }
@@ -118,47 +132,67 @@ class ValidateUserAccessMiddleware {
     };
   }
 
-  /**
-   * Filter farms to only include those associated with the monitor
-   * @param {Array} farms - Array of farms from the controller response
-   * @param {Number} id_user - ID of the monitor
-   * @returns {Array} Filtered array of farms
-   */
   async filterFarmsByMonitor(farms, id_user) {
     try {
-      if (!Array.isArray(farms)) {
-        return farms; // Return as is if not an array
-      }
-
-      // Get all farm IDs associated with this monitor
       const monitorFarms = await FarmUser.findAll({
-        where: { id_user: id_user },
+        where: {
+          id_user: id_user,
+          isActive: true
+        },
         attributes: ['id_farm']
       });
 
       const allowedFarmIds = monitorFarms.map(mf => mf.id_farm);
 
-      // Filter the farms array to only include farms associated with the monitor
-      return farms.filter(farm => allowedFarmIds.includes(farm.id));
+      if (allowedFarmIds.length === 0) {
+        return [];
+      }
+
+      if (Array.isArray(farms)) {
+        const filteredFarms = farms.filter(farm => allowedFarmIds.includes(farm.id));
+
+        const serializedFarms = filteredFarms.map(farm =>
+          farm.toJSON ? farm.toJSON() : farm
+        );
+
+        return serializedFarms;
+      } else if (farms && typeof farms === 'object') {
+
+        const fetchedFarms = await Farm.findAll({
+          where: {
+            id: allowedFarmIds,
+            isActive: true
+          },
+          order: [['id', 'DESC']]
+        });
+
+        const serializedFarms = fetchedFarms.map(farm => {
+          const farmData = farm.toJSON ? farm.toJSON() : farm;
+
+          return {
+            ...farmData,
+            latitude: farmData.latitude || "",
+            longitude: farmData.longitude || ""
+          };
+        });
+
+        return serializedFarms;
+      }
+
+      return [];
     } catch (error) {
       console.error('Error filtering farms by monitor:', error);
-      return []; // Return empty array in case of error
+      console.error(error.stack);
+      return [];
     }
   }
 
-  /**
-   * Filter modules to only include those associated with the monitor
-   * @param {Array} modules - Array of modules from the controller response
-   * @param {Number} monitorId - ID of the monitor
-   * @returns {Array} Filtered array of modules
-   */
   async filterModulesByMonitor(modules, monitorId) {
     try {
       if (!Array.isArray(modules)) {
-        return modules; // Return as is if not an array
+        return modules;
       }
 
-      // Get all module IDs associated with this monitor
       const monitorModules = await FarmUser.findAll({
         where: { monitor_id: monitorId },
         attributes: ['module_id']
@@ -166,27 +200,20 @@ class ValidateUserAccessMiddleware {
 
       const allowedModuleIds = monitorModules.map(mm => mm.module_id);
 
-      // Filter the modules array to only include modules associated with the monitor
       return modules.filter(module => allowedModuleIds.includes(module.id));
     } catch (error) {
       console.error('Error filtering modules by monitor:', error);
-      return []; // Return empty array in case of error
+      return [];
     }
   }
 
-  /**
-   * Restricts CRUD operations for monitors, allowing only GET requests
-   * @returns {Function} Express middleware function
-   */
   restrictCrudForMonitor() {
     return (req, res, next) => {
       try {
-        // Skip validation if not a monitor or if user data is missing
         if (!req.isMonitor || !req.user) {
           return next();
         }
 
-        // Allow only GET requests for monitors
         if (req.method !== 'GET') {
           return res.status(403).json(
             ApiResponse.createApiResponse('Access denied', [], [{
@@ -207,15 +234,9 @@ class ValidateUserAccessMiddleware {
     };
   }
 
-  /**
-   * Checks if a monitor has access to a specific resource (farm, module, etc.)
-   * @param {String} resourceType - Type of resource to check ('farm', 'module', etc.)
-   * @returns {Function} Express middleware function
-   */
   checkMonitorAccess(resourceType) {
     return async (req, res, next) => {
       try {
-        // Skip validation if not a monitor or if user data is missing
         if (!req.isMonitor || !req.user) {
           return next();
         }
@@ -227,7 +248,7 @@ class ValidateUserAccessMiddleware {
           case 'farm':
             const id_farm = req.params.id || req.body.id_farm;
             if (!id_farm) {
-              return next(); // No farm ID to check, proceed
+              return next();
             }
 
             hasAccess = await FarmUser.findOne({
@@ -241,7 +262,7 @@ class ValidateUserAccessMiddleware {
           case 'module':
             const moduleId = req.params.id || req.params.moduleId || req.body.module_id;
             if (!moduleId) {
-              return next(); // No module ID to check, proceed
+              return next();
             }
 
             hasAccess = await ModuleUser.findOne({
@@ -253,7 +274,6 @@ class ValidateUserAccessMiddleware {
             break;
 
           default:
-            // Unknown resource type, allow access
             return next();
         }
 

--- a/backend/app/routes/owner/farm.owner.route.js
+++ b/backend/app/routes/owner/farm.owner.route.js
@@ -16,22 +16,15 @@ const farmController = new FarmOwnerController(farmOwnerService);
 const validateRoleMiddleware = new ValidateRoleMiddleware();
 const validateUserAccessMiddleware = new ValidateUserAccessMiddleware();
 
-// Get farms for owner or monitor (filtered for monitors)
 router.get(
     '/',
     validateTokenMiddleware.validate.bind(validateTokenMiddleware),
-    // Allow both OWNER and MONITOR roles for GET requests
     validateRoleMiddleware.validate([Role.OWNER, Role.MONITOR]),
-    // Extend role validation to set proper flags based on role
     validateUserAccessMiddleware.extendRoleValidation(),
-    // Handle role-based access control and filter data for monitors
     validateUserAccessMiddleware.handleRoleBasedAccess(),
     validate(validateFarmPaginate),
     (req, res) => farmController.index(req, res)
 );
-
-// All other routes remain OWNER only
-// We don't need to modify them as validateRoleMiddleware already restricts access
 
 module.exports = router;
 

--- a/backend/app/routes/shared/module.route.js
+++ b/backend/app/routes/shared/module.route.js
@@ -5,12 +5,14 @@ const ModuleController = require("../../controllers/shared/module.controller");
 const ValidateTokenMiddleware = require("../../middleware/validateToken.middleware");
 const BlackListService = require("../../services/shared/blacklist.service");
 const ValidateRoleMiddleware = require("../../middleware/validateRole.middleware");
+const ValidateUserAccessMiddleware = require("../../middleware/validateUserAccess.middleware");
 const { ROLES: Role } = require("../../enums/roles.enum");
 const {validate} = require("../../middleware/validate.middleware");
 const {validateModulePaginate, validateIndexModules} = require("../../validators/shared/module.validator");
 
 const validateTokenMiddleware = new ValidateTokenMiddleware(new BlackListService());
 const validateRoleMiddleware = new ValidateRoleMiddleware();
+const validateUserAccessMiddleware = new ValidateUserAccessMiddleware();
 
 const moduleService = new ModuleService();
 const moduleController = new ModuleController(moduleService);
@@ -20,8 +22,15 @@ router.get(
     '/:farm_id',
     validateTokenMiddleware.validate.bind(validateTokenMiddleware),
     validate(validateIndexModules),
-    validateRoleMiddleware.validate([Role.ADMIN, Role.OWNER]),
+    // Permitir acceso a monitores
+    validateRoleMiddleware.validate([Role.ADMIN, Role.OWNER, Role.MONITOR]),
+    // Agregar middleware de validación de acceso
+    validateUserAccessMiddleware.extendRoleValidation(),
+    // Verificar acceso del monitor a la granja
+    validateUserAccessMiddleware.checkMonitorAccess('farm'),
     validate(validateModulePaginate),
+    // Filtrar módulos según el rol
+    validateUserAccessMiddleware.handleRoleBasedAccess(),
     (req, res) => moduleController.index(req, res)
 );
 

--- a/backend/app/routes/shared/module.route.js
+++ b/backend/app/routes/shared/module.route.js
@@ -17,19 +17,14 @@ const validateUserAccessMiddleware = new ValidateUserAccessMiddleware();
 const moduleService = new ModuleService();
 const moduleController = new ModuleController(moduleService);
 
-// Get All Modules by Farm
 router.get(
     '/:farm_id',
     validateTokenMiddleware.validate.bind(validateTokenMiddleware),
     validate(validateIndexModules),
-    // Permitir acceso a monitores
     validateRoleMiddleware.validate([Role.ADMIN, Role.OWNER, Role.MONITOR]),
-    // Agregar middleware de validación de acceso
     validateUserAccessMiddleware.extendRoleValidation(),
-    // Verificar acceso del monitor a la granja
     validateUserAccessMiddleware.checkMonitorAccess('farm'),
     validate(validateModulePaginate),
-    // Filtrar módulos según el rol
     validateUserAccessMiddleware.handleRoleBasedAccess(),
     (req, res) => moduleController.index(req, res)
 );

--- a/backend/app/swagger/paths/owner/farms/list_farms.json
+++ b/backend/app/swagger/paths/owner/farms/list_farms.json
@@ -1,0 +1,200 @@
+{
+  "/api/v2/owner/farms": {
+    "get": {
+      "tags": ["Owner/Farms"],
+      "summary": "List farms for the authenticated owner or monitor",
+      "description": "Retrieves a paginated list of farms associated with the authenticated user. This endpoint implements role-based access control through the validateUserAccess middleware with the following behavior:\n\n1. When accessed by an OWNER role: All farms owned by that user are returned with complete details.\n\n2. When accessed by a MONITOR role: The middleware automatically filters results to only include farms the monitor has been assigned to via the farm_user relationship with isActive=true. If a monitor has no farms assigned, an empty array is returned while maintaining the pagination metadata.\n\nThe filtering is handled completely by the middleware, which intercepts the response before it's sent to the client. This allows the controller to function normally without special logic for different roles.",
+      "security": [
+        {
+          "BearerAuth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "page",
+          "in": "query",
+          "description": "Page number for pagination",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "default": 1,
+            "minimum": 1
+          }
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "description": "Number of items per page",
+          "required": false,
+          "schema": {
+            "type": "integer",
+            "default": 10,
+            "minimum": 1,
+            "maximum": 100
+          }
+        },
+        {
+          "name": "sortField",
+          "in": "query",
+          "description": "Field to sort by",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "default": "id",
+            "enum": ["id", "name", "address", "createdAt", "updatedAt"]
+          }
+        },
+        {
+          "name": "sortOrder",
+          "in": "query",
+          "description": "Sort direction",
+          "required": false,
+          "schema": {
+            "type": "string",
+            "default": "DESC",
+            "enum": ["ASC", "DESC"]
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "List of farms successfully retrieved",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "User farms retrieved successfully"
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "example": 1
+                        },
+                        "name": {
+                          "type": "string",
+                          "example": "Granja de Tilapias El Dorado"
+                        },
+                        "address": {
+                          "type": "string",
+                          "example": "Carrera 15 #25-13, Bogotá, Colombia"
+                        },
+                        "latitude": {
+                          "type": "string",
+                          "example": "4.6097"
+                        },
+                        "longitude": {
+                          "type": "string",
+                          "example": "-74.0817"
+                        },
+                        "isActive": {
+                          "type": "boolean",
+                          "example": true
+                        },
+                        "createdAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "example": "2025-03-15T10:30:45.000Z"
+                        },
+                        "updatedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "example": "2025-04-05T16:20:30.000Z"
+                        }
+                      }
+                    }
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "example": []
+                  },
+                  "meta": {
+                    "type": "object",
+                    "properties": {
+                      "pagination": {
+                        "type": "object",
+                        "properties": {
+                          "total": {
+                            "type": "integer",
+                            "example": 10
+                          },
+                          "totalPages": {
+                            "type": "integer",
+                            "example": 1
+                          },
+                          "currentPage": {
+                            "type": "integer",
+                            "example": 1
+                          },
+                          "perPage": {
+                            "type": "integer",
+                            "example": 10
+                          },
+                          "hasNext": {
+                            "type": "boolean",
+                            "example": false
+                          },
+                          "hasPrev": {
+                            "type": "boolean",
+                            "example": false
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized - Authentication credentials were missing or invalid"
+        },
+        "403": {
+          "description": "Forbidden - User doesn't have the required role permissions (OWNER or MONITOR)"
+        },
+        "500": {
+          "description": "Internal Server Error",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Internal server error"
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {},
+                    "example": []
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "example": ["Failed to retrieve farms"]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "example": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/app/swagger/paths/shared/farms/get_farm_by_id.json
+++ b/backend/app/swagger/paths/shared/farms/get_farm_by_id.json
@@ -1,0 +1,132 @@
+{
+  "/api/v2/farms/{id}": {
+    "get": {
+      "tags": ["Shared/Farms"],
+      "summary": "Get farm details by ID",
+      "description": "Retrieves detailed information about a specific farm by its ID. Accessible by both OWNER and MONITOR roles. Monitors can only access farms they have been assigned to.",
+      "security": [
+        {
+          "BearerAuth": []
+        }
+      ],
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of the farm to retrieve",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 1
+          }
+        }
+      ],
+      "responses": {
+        "200": {
+          "description": "Farm details successfully retrieved",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Farm retrieved successfully"
+                  },
+                  "data": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "name": {
+                        "type": "string",
+                        "example": "Piscícola Boyacá"
+                      },
+                      "address": {
+                        "type": "string",
+                        "example": "Vereda La Esperanza, Municipio de Ventaquemada, Boyacá"
+                      },
+                      "latitude": {
+                        "type": "string",
+                        "example": "5.3735"
+                      },
+                      "longitude": {
+                        "type": "string",
+                        "example": "-73.5215"
+                      },
+                      "isActive": {
+                        "type": "boolean",
+                        "example": true
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-03-15T14:32:21.000Z"
+                      },
+                      "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2025-04-10T09:15:30.000Z"
+                      },
+                      "modules": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "integer",
+                              "example": 1
+                            },
+                            "name": {
+                              "type": "string",
+                              "example": "Módulo de Truchas"
+                            },
+                            "isActive": {
+                              "type": "boolean",
+                              "example": true
+                            },
+                            "createdAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2025-03-16T10:25:45.000Z"
+                            },
+                            "updatedAt": {
+                              "type": "string",
+                              "format": "date-time",
+                              "example": "2025-04-11T13:40:12.000Z"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "example": []
+                  }
+                }
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Unauthorized - Authentication credentials were missing or invalid"
+        },
+        "403": {
+          "description": "Forbidden - User doesn't have permission to access this farm"
+        },
+        "404": {
+          "description": "Farm not found"
+        },
+        "500": {
+          "description": "Internal Server Error"
+        }
+      }
+    }
+  }
+}

--- a/backend/app/swagger/paths/shared/modules/get_modules.json
+++ b/backend/app/swagger/paths/shared/modules/get_modules.json
@@ -3,7 +3,7 @@
     "get": {
       "tags": ["Shared/Modules"],
       "summary": "Get all modules for a specific farm",
-      "description": "Retrieves a paginated list of all active modules (isActive=true) for the specified farm with detailed information including creator and farm data. Only active users and farms are included in the relationships.",
+      "description": "Retrieves a paginated list of all active modules (isActive=true) for the specified farm with detailed information including creator and farm data. Only active users and farms are included in the relationships. This endpoint implements role-based access control through the validateUserAccessMiddleware. When accessed by an OWNER, all modules in the farm are returned. When accessed by a MONITOR, the middleware first verifies the monitor has access to the specified farm, then filters the modules to only include those the monitor has been assigned to.",
       "parameters": [
         {
           "in": "path",
@@ -54,7 +54,7 @@
       ],
       "security": [
         {
-          "apiKey": []
+          "BearerAuth": []
         }
       ],
       "responses": {
@@ -288,7 +288,7 @@
           }
         },
         "401": {
-          "description": "Unauthorized",
+          "description": "Unauthorized - Authentication credentials were missing or invalid",
           "content": {
             "application/json": {
               "schema": {
@@ -309,6 +309,38 @@
                       "type": "string"
                     },
                     "example": ["Authentication required to access this resource"]
+                  },
+                  "meta": {
+                    "type": "object",
+                    "example": {}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "403": {
+          "description": "Forbidden - User doesn't have permission to access this farm",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "string",
+                    "example": "Access denied"
+                  },
+                  "data": {
+                    "type": "array",
+                    "items": {},
+                    "example": []
+                  },
+                  "errors": {
+                    "type": "array",
+                    "items": {
+                      "type": "object"
+                    },
+                    "example": [{"error": "Monitor does not have access to this farm"}]
                   },
                   "meta": {
                     "type": "object",

--- a/test-resources/farms.postman_collection.json
+++ b/test-resources/farms.postman_collection.json
@@ -1,9 +1,9 @@
 {
 	"info": {
-		"_postman_id": "71d1fa4d-a178-4f4a-aab0-664f6b925570",
+		"_postman_id": "277201da-5079-4895-b13e-8e6f7304b197",
 		"name": "farms",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "13906554"
+		"_exporter_id": "37390175"
 	},
 	"item": [
 		{
@@ -46,10 +46,19 @@
 								"header": [
 									{
 										"key": "Authorization",
-										"value": "{{token}}",
+										"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZG5pIjoiMjQ0MTg2MDA2MyIsImlhdCI6MTc0MjAxNTMzMiwiZXhwIjoxNzQyMDMzMzMyfQ.SEyML748gsqHDfh2Q8IBX8RIqE0tvpt7tdtjlCNHfZg",
 										"type": "text"
 									}
 								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\r\n    \"name\": \"nuevaGranja\",\r\n    \"address\": \"nuevaGranja 123\",\r\n    \"latitude\": \"1.2\",\r\n    \"longitude\": \"2.123\",\r\n    \"users\": [2, 3]\r\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
 								"url": {
 									"raw": "{{server}}/api/v2/admin/farms/",
 									"host": [
@@ -225,6 +234,55 @@
 					]
 				},
 				{
+					"name": "montor",
+					"item": [
+						{
+							"name": "lists farm monitor",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{token}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{server}}/api/v2/owner/farms?page=1&limit=10&sortField=id&sortOrder=DESC",
+									"host": [
+										"{{server}}"
+									],
+									"path": [
+										"api",
+										"v2",
+										"owner",
+										"farms"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "1"
+										},
+										{
+											"key": "limit",
+											"value": "10"
+										},
+										{
+											"key": "sortField",
+											"value": "id"
+										},
+										{
+											"key": "sortOrder",
+											"value": "DESC"
+										}
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
 					"name": "login",
 					"event": [
 						{
@@ -256,9 +314,12 @@
 							}
 						},
 						"url": {
-							"raw": "{{server}}/api/v2/auth/login",
+							"raw": "https://backend.acuaterra.tech/api/v2/auth/login",
+							"protocol": "https",
 							"host": [
-								"{{server}}"
+								"backend",
+								"acuaterra",
+								"tech"
 							],
 							"path": [
 								"api",

--- a/test-resources/modules.postman_collection.json
+++ b/test-resources/modules.postman_collection.json
@@ -19,7 +19,7 @@
 								"header": [
 									{
 										"key": "Authorization",
-										"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjAsImRuaSI6IjY0NTM4MDM1MTYiLCJpYXQiOjE3NDIxNDY3MjYsImV4cCI6MTc0MjE2NDcyNn0.eP8Xqxv7JxWWWI26DrBuKqzVTWcV2NPRX2Ar5Cg2ypk",
+										"value": "{{token}}",
 										"type": "text"
 									},
 									{
@@ -29,12 +29,9 @@
 									}
 								],
 								"url": {
-									"raw": "https://backend.acuaterra.tech/api/v2/shared/modules/1?page=2&limit=1&sortField=id&sortOrder=DESC",
-									"protocol": "https",
+									"raw": "{{server}}/api/v2/shared/modules/1?page=2&limit=1&sortField=id&sortOrder=DESC",
 									"host": [
-										"backend",
-										"acuaterra",
-										"tech"
+										"{{server}}"
 									],
 									"path": [
 										"api",
@@ -77,13 +74,13 @@
 								"header": [
 									{
 										"key": "Authorization",
-										"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MiwiZG5pIjoiNTk5NTQ4MDYzMSIsImlhdCI6MTc0Mjc3OTA0NywiZXhwIjoxNzQyNzk3MDQ3fQ.XzvARF2lE_uQs4tr0_nim56XJyDOgMJabwPSUAXsHRc",
+										"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6NDIsImRuaSI6IjEwNjE0NTk4NyIsImlhdCI6MTc0NTY5NDQ5MiwiZXhwIjoxNzQ1NzEyNDkyfQ.XEDDeoL3UEubWRqZLBGS-TEU3KIdD58N3VW3PH-zHmM",
 										"type": "text"
 									}
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\r\n  \"name\": \"zz\",\r\n  \"location\": \"Ubicación del módulo 123\",\r\n  \"latitude\": \"12.34\",\r\n  \"longitude\": \"-45.67\",\r\n  \"species_fish\": \"Especie de pez\",\r\n  \"fish_quantity\": \"10\",\r\n  \"fish_age\": \"5\",\r\n  \"dimensions\": \"1x1x1\",\r\n  \"id_farm\": 1,\r\n  \"users\": [4]\r\n}",
+									"raw": "{\r\n  \"name\": \"Modulo B\",\r\n  \"location\": \"Ubicación del módulo 123\",\r\n  \"latitude\": \"12.34\",\r\n  \"longitude\": \"-45.67\",\r\n  \"species_fish\": \"Carpa\",\r\n  \"fish_quantity\": \"8\",\r\n  \"fish_age\": \"2\",\r\n  \"dimensions\": \"2x2x2\",\r\n  \"id_farm\": 7\r\n}",
 									"options": {
 										"raw": {
 											"language": "json"
@@ -229,6 +226,61 @@
 										"modules",
 										"32",
 										"monitors"
+									]
+								}
+							},
+							"response": []
+						}
+					]
+				},
+				{
+					"name": "monitor",
+					"item": [
+						{
+							"name": "list module monitor",
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "{{token}}",
+										"type": "text"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{server}}/api/v2/shared/modules/1?page=2&limit=1&sortField=id&sortOrder=DESC",
+									"host": [
+										"{{server}}"
+									],
+									"path": [
+										"api",
+										"v2",
+										"shared",
+										"modules",
+										"1"
+									],
+									"query": [
+										{
+											"key": "page",
+											"value": "2"
+										},
+										{
+											"key": "limit",
+											"value": "1"
+										},
+										{
+											"key": "sortField",
+											"value": "id"
+										},
+										{
+											"key": "sortOrder",
+											"value": "DESC"
+										}
 									]
 								}
 							},

--- a/test-resources/user.postman_collection.json
+++ b/test-resources/user.postman_collection.json
@@ -410,7 +410,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{   \n    \"email\": \"owner_1@example.com\",\n    //\"email\": \"owner_2@example.com\",\n   //\"email\": \"user@example.com\",\n    //\"password\": \"r5ctmodc\"\n    //\"email\": \"admin@example.com\",\n    \"password\": \"password\"\n   //\"email\": \"e5c70c80-09c5-11f0-b581-7dbcc11a1b59-module@acuaterra.tech\",\n   //\"password\": \"1fd8c7c95352\"\n  //\"email\": \"8ff232e0-09c4-11f0-a8c0-676644a4555b-module@acuaterra.tech\",\n    //\"password\": \"55f52b145337\"\n    //\"email\": \"newadmin@acuaterra.tech\",\n    //\"password\": \"NewAdmin88\" \n}",
+							"raw": "{   \n    //\"email\": \"owner_1@example.com\",\n    //\"email\": \"owner_2@example.com\",\n   //\"email\": \"user@example.com\",\n    //\"email\": \"admin@example.com\",\n    //\"password\": \"password\",\n    //\"email\": \"hobbie7899@gmail.com\",\n    //\"password\": \"Onix99*\"\n    \"email\": \"ansufati@acuaterra.tech\",\n    \"password\": \"25d8f843\"\n}",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION
### Link Jira
[AQ-167](https://aquaterra-sena.atlassian.net/browse/AQ-167?atlOrigin=eyJpIjoiOWE0ZWQ2MmY1ZGJjNGIxN2JjNDhhYWFlYzU0MTI1YWIiLCJwIjoiaiJ9)

## Description
   Implementation of middleware to work on specific routes that are already in operation for the owner role with indicated behavior depending on whether it is a login with the monitor role. We added the update of the Swagger documentation with the middleware covering these routes for the monitor. We updated the Postman collections.
## New Environments
![image](https://github.com/user-attachments/assets/ca02a30e-5c1c-4cd5-83dc-d8da506f56e0)  
![image](https://github.com/user-attachments/assets/4a1c350e-cb7f-44fa-8f08-9fae0dddd405)
![image](https://github.com/user-attachments/assets/6fe4e549-42d7-4402-aa27-e54c01605369)

