### PR TITLE
AQ 186 Configuration list notifications

### DIFF
--- a/backend/app/swagger/paths/shared/notifications/list_notifications.json
+++ b/backend/app/swagger/paths/shared/notifications/list_notifications.json
@@ -3,7 +3,7 @@
     "get": {
       "tags": ["Shared/Notifications"],
       "summary": "List user notifications",
-      "description": "Retrieves a paginated list of notifications for the authenticated user with OWNER or MONITOR role.",
+"description": "Retrieves a paginated list of notifications for the authenticated user with OWNER or MONITOR role, limited to current day and previous day.",
       "parameters": [
         {
           "in": "query",
@@ -43,8 +43,8 @@
         }
       ],
       "responses": {
-        "200": {
-          "description": "Successful operation - notifications retrieved",
+"200": {
+          "description": "Successful operation - notifications retrieved from current day and previous day",
           "content": {
             "application/json": {
               "schema": {
@@ -105,8 +105,9 @@
                       "pagination": {
                         "type": "object",
                         "properties": {
-                          "totalItems": {
+"totalItems": {
                             "type": "integer",
+                            "description": "Total notifications within the last 48 hours",
                             "example": 25
                           },
                           "totalPages": {


### PR DESCRIPTION
### Link Jira
[AQ-186](https://aquaterra-sena.atlassian.net/browse/AQ-186?atlOrigin=eyJpIjoiOWE0ZWQ2MmY1ZGJjNGIxN2JjNDhhYWFlYzU0MTI1YWIiLCJwIjoiaiJ9)

## Description
   Configure the notification listing service to only show notifications from the current day and those from the previous day, so that the notification history is not listed, since when viewed in the mobile app, the history of all notifications is shown and it is not user-friendly at all and added the feature update to the swagger documentation
## New Environments
   
### Screenshots
  
  
![image](https://github.com/user-attachments/assets/9baaab70-b02f-4c65-a286-fdc784e4b9fc)
![image](https://github.com/user-attachments/assets/9951b3b0-9ae8-45e5-8081-493f0a73cec6)
![image](https://github.com/user-attachments/assets/8b224e89-d58b-45eb-ad46-7871dc809a09)

